### PR TITLE
Fixed deprecation in Rails 3.2 where InstanceMethods is no longer included in Rails 4.0

### DIFF
--- a/lib/generator_spec/test_case.rb
+++ b/lib/generator_spec/test_case.rb
@@ -34,17 +34,15 @@ module GeneratorSpec
       end
     end
   
-    module InstanceMethods
-      def method_missing(method_sym, *arguments, &block)
-        self.test_case_instance.send(method_sym, *arguments, &block)
-      end
-      
-      def respond_to?(method_sym, include_private = false)
-        if self.test_case_instance.respond_to?(method_sym)
-          true
-        else
-          super
-        end
+    def method_missing(method_sym, *arguments, &block)
+      self.test_case_instance.send(method_sym, *arguments, &block)
+    end
+
+    def respond_to?(method_sym, include_private = false)
+      if self.test_case_instance.respond_to?(method_sym)
+        true
+      else
+        super
       end
     end
   end


### PR DESCRIPTION
Message was (from Refinery CMS):
DEPRECATION WARNING: The InstanceMethods module inside ActiveSupport::Concern will be no longer included automatically. Please define instance methods directly in #Class:0x007fb2e8a65610 instead. (called from include at /code/parndt/Refinery/core/spec/lib/generators/refinery/cms/cms_generator_spec.rb:7)

Thanks for the library!
