### PR TITLE
Make the migration matcher fail if passed a bad filename

### DIFF
--- a/lib/generator_spec/matcher.rb
+++ b/lib/generator_spec/matcher.rb
@@ -43,7 +43,7 @@ module GeneratorSpec
         file_name = migration_file_name(root, @name)
         
         unless file_name && file_name.exist?
-          throw :failure, file_name
+          throw :failure, @name
         end
         
         check_contents(file_name)


### PR DESCRIPTION
If a migration file is found not to exist, its name is set to nil, and this is thrown up the stack as a failure at matcher.rb#L46. 

This then gets interpreted as a successful match at matcher.rb#L129.

Avoid this by returning the requested @name to trigger a failed match.
