### PR TITLE
RSpec should be a runtime dependency

### DIFF
--- a/generator_spec.gemspec
+++ b/generator_spec.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.add_dependency 'activerecord', ['>= 3.0', '< 4.0']
   s.add_dependency 'railties', ['>= 3.0', '< 4.0']
-  s.add_development_dependency 'rspec'
+  s.add_dependency 'rspec'
   s.add_development_dependency 'fakefs', '~> 0.4.1'
 end


### PR DESCRIPTION
Because of https://github.com/stevehodgkiss/generator_spec/blob/master/lib/generator_spec/test_case.rb#L2
`rspec` needs to be a runtime dep and not a development dep
