### PR TITLE
Don't require 'rspec' at runtime

### DIFF
--- a/lib/generator_spec/test_case.rb
+++ b/lib/generator_spec/test_case.rb
@@ -1,5 +1,4 @@
 require 'active_record'
-require 'rspec'
 require 'rails/generators/test_case'
 require 'generator_spec/matcher'
 


### PR DESCRIPTION
Because it is assumed the gem is used in the context of rspec itself it
is unecessary to require the 'rspec' gem.

This is important because of a recent change to 'rspec-rails'. That gem
no longer installs 'rspec' itself:
https://github.com/rspec/rspec-rails/commit/f5a573518420629b80f10bf1b8a01faf54ae1e1d
