### PR TITLE
Add ActiveSupport dependency rather than ActiveRecord

### DIFF
--- a/generator_spec.gemspec
+++ b/generator_spec.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
-  s.add_dependency 'activerecord', ['>= 3.0', '< 4.0']
+  s.add_dependency 'activesupport', ['>= 3.0', '< 4.0']
   s.add_dependency 'railties', ['>= 3.0', '< 4.0']
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'fakefs', '~> 0.4.1'

--- a/lib/generator_spec/test_case.rb
+++ b/lib/generator_spec/test_case.rb
@@ -1,4 +1,4 @@
-require 'active_record'
+require 'active_support/all'
 require 'rails/generators/test_case'
 require 'generator_spec/matcher'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,4 @@
 require 'bundler/setup'
-require 'active_record'
 require 'rspec'
 require 'generator_spec/test_case'
 require 'fakefs/spec_helpers'

--- a/spec/support/test_generator/templates/migration.rb
+++ b/spec/support/test_generator/templates/migration.rb
@@ -1,3 +1,5 @@
-class TestMigration < ActiveRecord::Migration
+if defined?(ActiveRecord)
+  class TestMigration < ActiveRecord::Migration
   
+  end
 end


### PR DESCRIPTION
Right now you can't use GeneratorSpec with any ORM that conflicts with ActiveRecord being loaded (DataMapper, and perhaps others).  However, the only thing that ActiveRecord is required for are the Migration specs, which are AR-specific anyway. This changes the dependency to be on ActiveSupport so GeneratorSpec can be used with DM.  All specs still pass fine.
