### PR TITLE
Remove explicit restriction of rails version

### DIFF
--- a/generator_spec.gemspec
+++ b/generator_spec.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
-  s.add_dependency 'activerecord', ['>= 3.0', '< 4.0']
-  s.add_dependency 'railties', ['>= 3.0', '< 4.0']
+  s.add_dependency 'activerecord', ['>= 3.0']
+  s.add_dependency 'railties', ['>= 3.0']
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'fakefs', '~> 0.4.1'
 end


### PR DESCRIPTION
Testing a gem on rails 4 I ran into this problem. With rails `4.0.0.rc1` everything works fine, but with the master branch bundler throws up:

Gemfile:

``` ruby
gem "generator_spec", :path => "/Users/tom/projects/generator_spec" # Local path of this fork
gem 'rails', :git => 'git://github.com/rails/rails.git'
```

``` shell
bundle update
Updating git://github.com/rails/rails.git
Fetching gem metadata from https://rubygems.org/.......
Fetching gem metadata from https://rubygems.org/..
Resolving dependencies...
Bundler could not find compatible versions for gem "railties":
  In Gemfile:
    generator_spec (>= 0) ruby depends on
      railties (< 4.0, >= 3.0) ruby

    rails (>= 0) ruby depends on
      railties (4.1.0.beta)
```

I removed the non-rails4 restriction on the version and everything works fine, so I'm not sure why the limitation is there.
Tests and everything, or am I missing something?
