### PR TITLE
Lock 2.14 rspec and use mock instead of double for mocking.

### DIFF
--- a/generator_spec.gemspec
+++ b/generator_spec.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.add_dependency 'activesupport', ['>= 3.0', '<= 4.0']
   s.add_dependency 'railties', ['>= 3.0', '<= 4.0']
-  s.add_development_dependency 'rspec'
+  s.add_development_dependency 'rspec', '~> 2.14.0'
   s.add_development_dependency 'fakefs', '~> 0.4.1'
 end

--- a/spec/generator_spec/test_case_spec.rb
+++ b/spec/generator_spec/test_case_spec.rb
@@ -10,7 +10,7 @@ describe GeneratorSpec::TestCase do
       self.should_receive(:described_class).and_return(TestClass)
       include GeneratorSpec::TestCase
     end
-    @klass.test_case_instance = mock
+    @klass.test_case_instance = double
   end
   
   it 'passes unknown messages on to test_case_instance' do


### PR DESCRIPTION
In rspec 2.14 is mock deprecated and will be removed in rspec 3.0.
