### PR TITLE
Generator example group 

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,14 @@ group :test do
 end
 ```
 
-Spec:
+Spec (files in `spec/lib/generators` are recognized as generator type example group):
 
 ```ruby
 # spec/lib/generators/test/test_generator_spec.rb
     
-require "generator_spec/test_case"
+require "generator_spec"
 
 describe TestGenerator do
-  include GeneratorSpec::TestCase
   destination File.expand_path("../../tmp", __FILE__)
   arguments %w(something)
 
@@ -38,8 +37,7 @@ end
 An RSpec file matching DSL is also provided, taken with permission from [beard](https://github.com/carlhuda/beard/blob/master/spec/support/matcher.rb) by [carlhuda](https://github.com/carlhuda).
 
 ```ruby
-describe TestGenerator, "using custom matcher" do
-  include GeneratorSpec::TestCase
+describe TestGenerator, "using custom matcher", type: :generator do
   destination File.expand_path("../../tmp", __FILE__)
   
   before do

--- a/lib/generator_spec.rb
+++ b/lib/generator_spec.rb
@@ -1,0 +1,12 @@
+require 'rspec'
+require 'generator_spec/generator_example_group'
+
+RSpec::configure do |c|
+  def c.escaped_path(*parts)
+    Regexp.compile(parts.join('[\\\/]') + '[\\\/]')
+  end
+
+  c.include GeneratorSpec::GeneratorExampleGroup, :type => :generator, :example_group => {
+    :file_path => c.escaped_path(%w[spec lib generators])
+  }
+end

--- a/lib/generator_spec/generator_example_group.rb
+++ b/lib/generator_spec/generator_example_group.rb
@@ -1,0 +1,6 @@
+require 'generator_spec/test_case'
+
+module GeneratorSpec::GeneratorExampleGroup
+  extend ActiveSupport::Concern
+  include GeneratorSpec::TestCase
+end

--- a/spec/generator_spec/generator_example_group_spec.rb
+++ b/spec/generator_spec/generator_example_group_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+module GeneratorSpec
+  describe GeneratorExampleGroup do
+    it { should be_included_in_files_in('./spec/lib/generators/') }
+  end
+end

--- a/spec/generator_spec/test_case_spec.rb
+++ b/spec/generator_spec/test_case_spec.rb
@@ -24,8 +24,7 @@ describe GeneratorSpec::TestCase do
   end
 end
 
-describe TestGenerator, 'using normal assert methods' do
-  include GeneratorSpec::TestCase
+describe TestGenerator, 'using normal assert methods', :type => 'generator' do
   destination File.expand_path('../../tmp', __FILE__)
   arguments %w(test --test)
   
@@ -47,8 +46,7 @@ describe TestGenerator, 'using normal assert methods' do
   end
 end
 
-describe TestGenerator, 'with contexts' do
-  include GeneratorSpec::TestCase
+describe TestGenerator, 'with contexts', :type => 'generator' do
   destination File.expand_path('../../tmp', __FILE__)
   before { prepare_destination }
   

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 require 'bundler/setup'
 require 'rspec'
-require 'generator_spec/test_case'
+require 'generator_spec'
 
 Dir[Pathname.new(File.expand_path('../', __FILE__)).join('support/**/*.rb')].each {|f| require f}
 

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -1,0 +1,21 @@
+# taken from https://github.com/rspec/rspec-rails/blob/master/spec/support/helpers.rb
+module Helpers
+  def stub_metadata(additional_metadata)
+    stub_metadata = metadata_with(additional_metadata)
+    RSpec::Core::ExampleGroup.stub(:metadata) { stub_metadata }
+  end
+
+  def metadata_with(additional_metadata)
+    m = RSpec::Core::Metadata.new
+    m.process("example group")
+
+    group_metadata = additional_metadata.delete(:example_group)
+    if group_metadata
+      m[:example_group].merge!(group_metadata)
+    end
+    m.merge!(additional_metadata)
+    m
+  end
+
+  RSpec.configure {|c| c.include self}
+end

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -1,0 +1,11 @@
+# taken from  https://raw.github.com/rspec/rspec-rails/master/spec/support/matchers.rb
+
+RSpec::Matchers::define :be_included_in_files_in do |path|
+  match do |mod|
+    stub_metadata(
+      :example_group => {:file_path => "#{path}whatever_spec.rb:15"}
+    )
+    group = RSpec::Core::ExampleGroup.describe
+    group.included_modules.include?(mod)
+  end
+end


### PR DESCRIPTION
New generator example group and recognizing files under spec/lib/generators as generator example group.

Old `require "generator_spec/test_case"` works and is backward compatible. Only when you require only `generator_spec` it will include new example group.

Inspired by
- https://github.com/rspec/rspec-rails/blob/master/lib/rspec/rails/example.rb
- https://github.com/rspec/rspec-rails/blob/master/lib/rspec/rails/example/controller_example_group.rb
- https://github.com/rspec/rspec-rails/blob/master/spec/rspec/rails/example/controller_example_group_spec.rb
