### PR TITLE
Fix Rubinius builds on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ rvm:
   - 2.0.0
   - 1.9.3
   - jruby-19mode
-  - rbx-19mode
+  - rbx

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,8 @@
 source "http://rubygems.org"
 
+platforms :rbx do
+  gem 'rubysl', '~> 2.0'
+  gem 'rubinius-developer_tools'
+end
+
 gemspec


### PR DESCRIPTION
1. Updated the .travis.yml Rubinius rvm to 'rbx'
2. Added the required Rubinius gems to the Gemfile.
