### PR TITLE
fix deprecation for rspec 3

### DIFF
--- a/generator_spec.gemspec
+++ b/generator_spec.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.add_dependency 'activesupport', ['>= 3.0.0']
   s.add_dependency 'railties', ['>= 3.0.0']
-  s.add_development_dependency 'rspec', '>= 2.14.0'
+  s.add_development_dependency 'rspec', '>= 2.99.0'
 end

--- a/lib/generator_spec.rb
+++ b/lib/generator_spec.rb
@@ -6,7 +6,5 @@ RSpec::configure do |c|
     Regexp.compile(parts.join('[\\\/]') + '[\\\/]')
   end
 
-  c.include GeneratorSpec::GeneratorExampleGroup, :type => :generator, :example_group => {
-    :file_path => c.escaped_path(%w[spec lib generators])
-  }
+  c.include GeneratorSpec::GeneratorExampleGroup, :type => :generator, :file_path => c.escaped_path(%w[spec lib generators])
 end


### PR DESCRIPTION
The subhash syntax was deprecated in RSpec 3. This isn't backwards compatible, we could make it backwards compatible but I wasn't sure of the best way to detect which version we should use. Let me know if you have any suggestions on that front or if you're happy to just upgrade the rspec dependency. Thanks!
