### PR TITLE
changes deprecated rspec syntax

### DIFF
--- a/lib/generator_spec.rb
+++ b/lib/generator_spec.rb
@@ -6,7 +6,5 @@ RSpec::configure do |c|
     Regexp.compile(parts.join('[\\\/]') + '[\\\/]')
   end
 
-  c.include GeneratorSpec::GeneratorExampleGroup, :type => :generator, :example_group => {
-    :file_path => c.escaped_path(%w[spec lib generators])
-  }
+  c.include GeneratorSpec::GeneratorExampleGroup, :type => :generator, :file_path => c.escaped_path(%w[spec lib generators])
 end


### PR DESCRIPTION
this fixes error I'm getting with rspec 3. see below.

```
/Users/jason/.rvm/rubies/ruby-2.1.0/bin/ruby -I/Users/jason/.rvm/gems/ruby-2.1.0/gems/rspec-core-3.1.2/lib:/Users/jason/.rvm/gems/ruby-2.1.0/gems/rspec-support-3.1.0/lib /Users/jason/.rvm/gems/ruby-2.1.0/gems/rspec-core-3.1.2/exe/rspec --pattern spec/\*\*/\*_spec.rb
Coverage report generated for RSpec to /Users/jason/Projects/nondestructive_migrations/coverage. 32 / 40 LOC (80.0%) covered.
/Users/jason/.rvm/gems/ruby-2.1.0/gems/rspec-core-3.1.2/lib/rspec/core/formatters/deprecation_formatter.rb:186:in `puts': Filtering by an `:example_group` subhash is deprecated. Use the subhash to filter directly instead. Called from /Users/jason/.rvm/gems/ruby-2.1.0/gems/generator_spec-0.9.2/lib/generator_spec.rb:9:in `block in <top (required)>'. (RSpec::Core::DeprecationError)
    from /Users/jason/.rvm/gems/ruby-2.1.0/gems/rspec-core-3.1.2/lib/rspec/core/formatters/deprecation_formatter.rb:125:in `print_deprecation_message'
    from /Users/jason/.rvm/gems/ruby-2.1.0/gems/rspec-core-3.1.2/lib/rspec/core/formatters/deprecation_formatter.rb:36:in `deprecation'
    from /Users/jason/.rvm/gems/ruby-2.1.0/gems/rspec-core-3.1.2/lib/rspec/core/reporter.rb:134:in `block in notify'
    from /Users/jason/.rvm/gems/ruby-2.1.0/gems/rspec-core-3.1.2/lib/rspec/core/reporter.rb:133:in `each'
    from /Users/jason/.rvm/gems/ruby-2.1.0/gems/rspec-core-3.1.2/lib/rspec/core/reporter.rb:133:in `notify'
    from /Users/jason/.rvm/gems/ruby-2.1.0/gems/rspec-core-3.1.2/lib/rspec/core/reporter.rb:106:in `deprecation'
    from /Users/jason/.rvm/gems/ruby-2.1.0/gems/rspec-core-3.1.2/lib/rspec/core/warnings.rb:11:in `deprecate'
    from /Users/jason/.rvm/gems/ruby-2.1.0/gems/rspec-core-3.1.2/lib/rspec/core/metadata.rb:52:in `build_hash_from'
    from /Users/jason/.rvm/gems/ruby-2.1.0/gems/rspec-core-3.1.2/lib/rspec/core/configuration.rb:1014:in `include'
    from /Users/jason/.rvm/gems/ruby-2.1.0/gems/generator_spec-0.9.2/lib/generator_spec.rb:9:in `block in <top (required)>'
    from /Users/jason/.rvm/gems/ruby-2.1.0/gems/rspec-core-3.1.2/lib/rspec/core.rb:81:in `configure'
    from /Users/jason/.rvm/gems/ruby-2.1.0/gems/generator_spec-0.9.2/lib/generator_spec.rb:4:in `<top (required)>'
    from /Users/jason/Projects/nondestructive_migrations/spec/generators/nondestructive_migration_generator_spec.rb:5:in `require'
    from /Users/jason/Projects/nondestructive_migrations/spec/generators/nondestructive_migration_generator_spec.rb:5:in `<top (required)>'
    from /Users/jason/.rvm/gems/ruby-2.1.0/gems/rspec-core-3.1.2/lib/rspec/core/configuration.rb:1105:in `load'
    from /Users/jason/.rvm/gems/ruby-2.1.0/gems/rspec-core-3.1.2/lib/rspec/core/configuration.rb:1105:in `block in load_spec_files'
    from /Users/jason/.rvm/gems/ruby-2.1.0/gems/rspec-core-3.1.2/lib/rspec/core/configuration.rb:1105:in `each'
    from /Users/jason/.rvm/gems/ruby-2.1.0/gems/rspec-core-3.1.2/lib/rspec/core/configuration.rb:1105:in `load_spec_files'
    from /Users/jason/.rvm/gems/ruby-2.1.0/gems/rspec-core-3.1.2/lib/rspec/core/runner.rb:96:in `setup'
    from /Users/jason/.rvm/gems/ruby-2.1.0/gems/rspec-core-3.1.2/lib/rspec/core/runner.rb:84:in `run'
    from /Users/jason/.rvm/gems/ruby-2.1.0/gems/rspec-core-3.1.2/lib/rspec/core/runner.rb:69:in `run'
    from /Users/jason/.rvm/gems/ruby-2.1.0/gems/rspec-core-3.1.2/lib/rspec/core/runner.rb:37:in `invoke'
    from /Users/jason/.rvm/gems/ruby-2.1.0/gems/rspec-core-3.1.2/exe/rspec:4:in `<main>'
/Users/jason/.rvm/rubies/ruby-2.1.0/bin/ruby -I/Users/jason/.rvm/gems/ruby-2.1.0/gems/rspec-core-3.1.2/lib:/Users/jason/.rvm/gems/ruby-2.1.0/gems/rspec-support-3.1.0/lib /Users/jason/.rvm/gems/ruby-2.1.0/gems/rspec-core-3.1.2/exe/rspec --pattern spec/\*\*/\*_spec.rb failed
jason@admins-MacBook-Air-4:nondestructive_migrations (master)$ 
```
