### PR TITLE
Avoid errors when using do/end

### DIFF
--- a/lib/generator_spec/matcher.rb
+++ b/lib/generator_spec/matcher.rb
@@ -131,6 +131,8 @@ module GeneratorSpec
     end
 
     def have_structure(&block)
+      error = 'You must pass a block to have_structure (Use {} instead of do/end!)'
+      raise RuntimeError, error unless block_given?
       Root.new(&block)
     end
   end

--- a/spec/generator_spec/matcher_spec.rb
+++ b/spec/generator_spec/matcher_spec.rb
@@ -46,6 +46,18 @@ describe TestGenerator, 'using custom matcher' do
       }
     }.to raise_error
   end
+
+  it 'fails when it doesnt match with do/end instead of {}' do
+    expect {
+      expect(destination_root).to have_structure do
+        directory 'db' do
+          directory 'migrate' do
+            no_file '123_create_tests.rb'
+          end
+        end
+      end
+    }.to raise_error RuntimeError, /You must pass a block/
+  end
 end
 
 module GeneratorSpec


### PR DESCRIPTION
I've been bitten by this and I bet that other people too.
If you use `do/end` instead of `{}` (which is more usual in multi-line blocks), the test will always pass, whatever you add, because no block is being passed to `have_structure` (`to` is taking it I think).

I see the gem is not very active, but it seems the most convenient way to test generators, so it'd be nice to have this merged!  