### PR TITLE
Use a custom temporary directory for matcher spec.

### DIFF
--- a/spec/generator_spec/matcher_spec.rb
+++ b/spec/generator_spec/matcher_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'tmpdir'
 
-TMP_ROOT = Pathname.new(Dir.tmpdir)
+TMP_ROOT = Pathname.new(Dir.mktmpdir('generator_spec'))
 
 describe TestGenerator, 'using custom matcher' do
   include GeneratorSpec::TestCase


### PR DESCRIPTION
We require the temporary directory to be deleted by the spec.
This directory thus should not conflict with an existing one.

Fixes #33.