### PR TITLE
Compatible with Ruby 3.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "http://rubygems.org"
 
 platforms :rbx do
-  gem 'rubysl', '~> 2.0'
+  # gem 'rubysl', '~> 2.2'
   gem 'rubinius-developer_tools'
 end
 

--- a/generator_spec.gemspec
+++ b/generator_spec.gemspec
@@ -6,9 +6,9 @@ Gem::Specification.new do |s|
   s.name        = "generator_spec"
   s.version     = GeneratorSpec::VERSION
   s.platform    = Gem::Platform::RUBY
-  s.authors     = ["Steve Hodgkiss", "AMG"]
+  s.authors     = ["Steve Hodgkiss"]
   s.email       = ["steve@hodgkiss.me.uk"]
-  s.homepage    = "https://github.com/anitagraham/generator_spec"
+  s.homepage    = "https://github.com/stevehodgkiss/generator_spec"
   s.license     = 'MIT'
   s.summary     = %q{Test Rails generators with RSpec}
   s.description = %q{Test Rails generators with RSpec}

--- a/generator_spec.gemspec
+++ b/generator_spec.gemspec
@@ -6,9 +6,9 @@ Gem::Specification.new do |s|
   s.name        = "generator_spec"
   s.version     = GeneratorSpec::VERSION
   s.platform    = Gem::Platform::RUBY
-  s.authors     = ["Steve Hodgkiss"]
+  s.authors     = ["Steve Hodgkiss", "AMG"]
   s.email       = ["steve@hodgkiss.me.uk"]
-  s.homepage    = "https://github.com/stevehodgkiss/generator_spec"
+  s.homepage    = "https://github.com/anitagraham/generator_spec"
   s.license     = 'MIT'
   s.summary     = %q{Test Rails generators with RSpec}
   s.description = %q{Test Rails generators with RSpec}

--- a/lib/generator_spec/matcher.rb
+++ b/lib/generator_spec/matcher.rb
@@ -2,7 +2,7 @@ module GeneratorSpec
   module Matcher
     # Taken (with permission) from beard by Yahuda Katz
     # https://github.com/carlhuda/beard
-  
+
     class File
       def initialize(name, &block)
         @contents = []
@@ -24,9 +24,9 @@ module GeneratorSpec
 
         check_contents(root.join(@name))
       end
-      
+
       protected
-      
+
       def check_contents(file)
         contents = ::File.read(file)
 
@@ -37,20 +37,20 @@ module GeneratorSpec
         end
       end
     end
-    
+
     class Migration < File
       def matches?(root)
         file_name = migration_file_name(root, @name)
-        
+
         unless file_name && file_name.exist?
           throw :failure, @name
         end
-        
+
         check_contents(file_name)
       end
-      
+
       protected
-      
+
       def migration_file_name(root, name) #:nodoc:
         directory, file_name = ::File.dirname(root.join(name)), ::File.basename(name).sub(/\.rb$/, '')
         migration = Dir.glob("#{directory}/[0-9]*_*.rb").grep(/\d+_#{file_name}.rb$/).first
@@ -83,7 +83,7 @@ module GeneratorSpec
       def location(name)
         [@root, name].compact.join("/")
       end
-      
+
       def migration(name, &block)
         @tree[name] = Migration.new(location(name), &block)
       end
@@ -131,6 +131,7 @@ module GeneratorSpec
     end
 
     def have_structure(&block)
+      description = "File and directory structure"
       error = 'You must pass a block to have_structure (Use {} instead of do/end!)'
       raise RuntimeError, error unless block_given?
       Root.new(&block)

--- a/lib/generator_spec/matcher.rb
+++ b/lib/generator_spec/matcher.rb
@@ -4,6 +4,11 @@ module GeneratorSpec
     # https://github.com/carlhuda/beard
 
     class File
+
+      def description
+        'file attributes and content'
+      end
+
       def initialize(name, &block)
         @contents = []
         @name = name
@@ -39,6 +44,10 @@ module GeneratorSpec
     end
 
     class Migration < File
+      def description
+        'valid migration file'
+      end
+
       def matches?(root)
         file_name = migration_file_name(root, @name)
 
@@ -60,6 +69,10 @@ module GeneratorSpec
 
     class Directory
       attr_reader :tree
+
+      def description
+        'has directory structure'
+      end
 
       def initialize(root = nil, &block)
         @tree = {}
@@ -110,6 +123,10 @@ module GeneratorSpec
     end
 
     class Root < Directory
+      def description
+        'have specified directory structure'
+      end
+
       def failure_message
         if @failure.is_a?(Array) && @failure[0] == :not
           "Structure should not have had #{@failure[1]}, but it did"
@@ -131,7 +148,6 @@ module GeneratorSpec
     end
 
     def have_structure(&block)
-      description = "File and directory structure"
       error = 'You must pass a block to have_structure (Use {} instead of do/end!)'
       raise RuntimeError, error unless block_given?
       Root.new(&block)

--- a/lib/generator_spec/version.rb
+++ b/lib/generator_spec/version.rb
@@ -1,3 +1,3 @@
 module GeneratorSpec
-  VERSION = '0.9.4'
+  VERSION = '0.9.5'
 end

--- a/spec/generator_spec/matcher_spec.rb
+++ b/spec/generator_spec/matcher_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'tmpdir'
 
-TMP_ROOT = Pathname.new(Dir.tmpdir)
+TMP_ROOT = Pathname.new(Dir.tmpdir).join('generator')
 
 describe TestGenerator, 'using custom matcher' do
   include GeneratorSpec::TestCase
@@ -72,6 +72,7 @@ module GeneratorSpec
         let(:location) { TMP_ROOT.join('test_file') }
 
         context 'with no contains' do
+
           it 'doesnt throw if the file exists' do
             write_file(location, '')
             expect {
@@ -84,6 +85,7 @@ module GeneratorSpec
               file.matches?(TMP_ROOT)
             }.to throw_symbol(:failure)
           end
+
         end
 
         context 'with contains' do


### PR DESCRIPTION
In `matcher_spec.rb` make TMP_ROOT a subdirectory of Dir.tmpdir as contents of TMP_ROOT were not being deleted.

Tested with Ruby 3.2.2
Commented out `gem 'rubysl', '~> 2.0'` from Gemfile.  
`bundle install` with either '~>2.0' or '~2.2' (the latest version) failed because they depend on Ruby ~> 2.0.
The `rubysl` entry on rubygems.org points to a non-existent homepage on github.

